### PR TITLE
Remove exit

### DIFF
--- a/extra_recipe/unjail.m
+++ b/extra_recipe/unjail.m
@@ -187,7 +187,8 @@ unjail2(uint64_t surfacevt)
 	
 	system("(echo 'Loading LaunchDaemons...'; /bin/launchctl load /Library/LaunchDaemons/0.reload.plist)&");
 	
-	exit(0);
+	// This line prevent to load 0.reload.plist You don't need it because 0.reload.plist kills the backboardd.
+	//exit(0);
 	
 	return 123456789;
 }


### PR DESCRIPTION
If you exit the app, you kill all sub processes. /bin/launchctl load /Library/LaunchDaemons/0.reload.plist is a sub process of the app, so the backboardd never restarts for me and I need to do it manual. And if the SpringBoard/backboardd restarts, why do you need to kill the app ?